### PR TITLE
Feature/hash table

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD 
     - name: docker build
       run: |
-        docker build ./fetch -t dewberrycsi/nwm-fetch-forecasts:1.0.1
+        docker build ./fetch -t dewberrycsi/nwm-fetch-forecasts:1.1.1
     - name: docker push
       run: |
-        docker push dewberrycsi/nwm-fetch-forecasts:1.0.1
+        docker push dewberrycsi/nwm-fetch-forecasts:1.1.1

--- a/README.md
+++ b/README.md
@@ -30,36 +30,36 @@ In order to run this container you'll need docker installed.
  - `-product`: the product requested. Can be either `short` or `medium`. 
     - If not entered, short range is assumed
     - If `medium` is specified and the date is before 2019-06-02, there will be a single ensemble member. If it is after that day, all ensemble members will be retrieved  
- - `-index`: the location in the netcdf files to pull stream flow
-    - all arguments tacked on to the end are assumed to be additional indicies
+ - `-comid`: the NHD comid to pull stream flow for
+    - all arguments tacked on to the end are assumed to be additional comids
 
 #### Examples
 
-Grabs short range forecast streamflow for multiple indices
+Grabs short range forecast streamflow for multiple comids
 ```shell
-docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -date_time 2019-01-02-15 -product short -index 900 101 181 1030 ...
+docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -date_time 2019-01-02-15 -product short -comid 900 101 181 1030 ...
 ```
 
-Grabs the latest short range forecast at index 1234
+Grabs the latest short range forecast at comid 1234
 ```shell
-docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -index 1234
+docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -comid 1234
 ```
 
-Grabs the medium range forecast at multiple indices
+Grabs the medium range forecast at multiple comids
 ```shell
-docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -date_time 2019-01-02-15 -product medium -index 900 101 181 1030 ...
+docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -date_time 2019-01-02-15 -product medium -comid 900 101 181 1030 ...
 ```
 
-Grabs retrospective data at multiple indices
+Grabs retrospective data at multiple comids
 ```shell
-docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -date_time 1999-01-02-15 -index 900 101 181 1030 ...
+docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -date_time 1999-01-02-15 -comid 900 101 181 1030 ...
 ```
 
 #### Outputs
 
 Results will be output to `STDOUT` as a json, and can be easily piped to a file as needed. For example:
 ```shell
-docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -index 1234 > results.json
+docker run --privileged dewberrycsi/nwm-fetch-forecasts:version -comid 1234 > results.json
 ```
 
 To format the json output with indentation:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         # target: dev
         target: prod
       container_name: fetch
-      image: dewberrycsi/nwm-fetch-forecasts:1.0.1
+      image: dewberrycsi/nwm-fetch-forecasts:1.1.1
       privileged: true
       volumes:
         - ./fetch:/fetch

--- a/fetch/Dockerfile
+++ b/fetch/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && \
     curl
 
 COPY --from=dev /fetch/main /
+COPY --from=dev /fetch/netcdf_index.csv /
 
 RUN mkdir /retrospective
 RUN mkdir /forecast

--- a/fetch/main.go
+++ b/fetch/main.go
@@ -40,17 +40,30 @@ func main() {
 
 	// Index (position) of streamflow data for comid of interest (900 selected at random)
 	flag.StringVar(&forecastProduct, "product", "short", "requested product: medium or short")
-	idx0 := flag.Uint64("index", 900, "netcdf file location (index) for streamflow value from desired comid")
+	idx0 := flag.Int64("comid", 900, "desired comid for streamflow value")
 	flag.Parse()
 
+	idxMap, err := utils.PositionCSVToMap("netcdf_index.csv")
+	utils.CheckError(err)
+
 	// Add all requested indices to idxs var for processing
-	var idxs []uint64 = []uint64{*idx0}
+	v, ok := idxMap[*idx0]
+	if !ok {
+		errMessage := fmt.Sprintf("Comid %d is not in the netcdf file", *idx0)
+		log.Fatal(errMessage)
+	}
+	var idxs []uint64 = []uint64{v}
 	additionalIDXs := flag.Args()
 
 	if len(additionalIDXs) > 0 {
 		for _, idx := range additionalIDXs {
-			idxINT, _ := strconv.Atoi(idx)
-			idxs = append(idxs, uint64(idxINT))
+			idxINT, _ := strconv.ParseInt(idx, 10, 64)
+			v, ok := idxMap[idxINT]
+			if !ok {
+				errMessage := fmt.Sprintf("Comid %d is not in the netcdf file", idxINT)
+				log.Fatal(errMessage)
+			}
+			idxs = append(idxs, uint64(v))
 		}
 	}
 

--- a/fetch/utils/forecast.go
+++ b/fetch/utils/forecast.go
@@ -151,7 +151,15 @@ func GetMediumRangePaths(dtm string, forecastEra string) []string {
 	cloudPaths := make([]string, 0)
 
 	forecastDTM, _ := time.Parse(userDateFormat, dtm)
+	for {
+		if !(forecastDTM.Hour() == 0 || forecastDTM.Hour() == 6 || forecastDTM.Hour() == 12 || forecastDTM.Hour() == 18) {
+			forecastDTM = forecastDTM.Add(time.Hour * -1)
+		} else {
+			break
+		}
+	}
 	roundedStart := time.Date(forecastDTM.Year(), forecastDTM.Month(), forecastDTM.Day(), 0, 0, 0, 0, forecastDTM.Location())
+
 	startYearMonthDay = forecastDTM.Format(nwmDateFormat)
 	requestedHour := forecastDTM.Hour()
 

--- a/fetch/utils/forecast.go
+++ b/fetch/utils/forecast.go
@@ -49,7 +49,7 @@ type StreamFlow struct {
 
 // ComIDPrediction ...
 type ComIDPrediction struct {
-	Comid int64   `json:"comid_index"`
+	Comid int64   `json:"comid"`
 	Value float64 `json:"flow"`
 }
 

--- a/fetch/utils/utils.go
+++ b/fetch/utils/utils.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"encoding/csv"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -48,4 +51,43 @@ func StringsToUint64s(strs []string) []uint64 {
 		uints = append(uints, uint64(i64))
 	}
 	return uints
+}
+
+// PositionCSVToMap ...
+func PositionCSVToMap(filePath string) (map[int64]uint64, error) {
+	outMap := make(map[int64]uint64)
+
+	// read csv file
+	csvfile, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf(err.Error())
+	}
+
+	defer csvfile.Close()
+
+	reader := csv.NewReader(csvfile)
+
+	rawCSVdata, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf(err.Error())
+	}
+
+	for i, record := range rawCSVdata {
+		if i != 0 {
+			i64, err := strconv.ParseInt(record[0], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf(err.Error())
+			}
+
+			position := uint64(i64)
+
+			comid, err := strconv.ParseInt(record[1], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf(err.Error())
+			}
+
+			outMap[comid] = position
+		}
+	}
+	return outMap, nil
 }


### PR DESCRIPTION
- Updates the image from version 1.0.1 to 1.1.1
- Adds the data file `fetch/netcdf_index.csv`
- Adds the ability to input comids instead of netcdf indexs
- Enforces grabbing the most recent medium range forecast instead of error out, as per #6

Closes #3
Closes #6 